### PR TITLE
Disabled back event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Contributions are always welcome even though this is a very basic game.
 
 To contribute, fork this repo, then make the changes you need to make.
 
-Please make sure you're editing the `Temp` branch and not the `Master` Branch.
+Please make sure you're editing the `dev` branch and not the `Master` Branch.
 
-Once the changes are done, commit them and then send me a Pull Request on the `Temp` branch.
+Once the changes are done, commit them and then send me a Pull Request on the `dev` branch.

--- a/src/js/Game.js
+++ b/src/js/Game.js
@@ -11,7 +11,8 @@ class Game {
 }
 
 Game.prototype.setupEventListeners = function() {
-  this.backEventListeners();
+  // Disabled back event listeners to avoid cheating/additional scoring by re-flipping matched cards.
+  // this.backEventListeners();
   this.cardFrontEventListeners();
 }
 


### PR DESCRIPTION
Players could re-flip matching cards to make additional points or force player to re-match cards if flipped by accident.. Thanks @flaura42 for pointing that out :) This is for #19 